### PR TITLE
managed_instance: sleep when reaching logfile EOF

### DIFF
--- a/testinstances/managed_instance.py
+++ b/testinstances/managed_instance.py
@@ -68,6 +68,7 @@ class ManagedInstance(object):
         while True:
             line = logfile.readline().strip()
             if not line:
+                time.sleep(.1)
                 continue
             self.log.info(line)
 


### PR DESCRIPTION
This prevents burning too many CPU cycles.  I think the little sleep is
acceptable: it doesn't come into play when multiple lines are available
for consumption.

Signed-off-by: Yung-Chin Oei <yungchin@yungchin.nl>