### PR TITLE
Add tox and support py26,py34, and use py.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .coverage
 build/
 dist/
+coverage.xml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,16 @@ Or, if you wanted to be fancy and avoid the process creation/termination cost fo
         collection.insert({'foo': 'bar'})
         self.assertEqual(collection.find({'foo': 'bar'}).next()['foo'], 'bar')
 
+Developing
+----------
+To run the tests you need to install all of the databases the tests run:
+
+.. code-block:: bash
+
+    $ sudo apt-get install redis-server mongodb-server
+
+Then you just run ``tox``.
+
 Roadmap
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,17 @@ Developing
 ----------
 To run the tests you need to install all of the databases the tests run:
 
+For Debian/Ubuntu:
+
 .. code-block:: bash
 
     $ sudo apt-get install redis-server mongodb-server
+
+For OSX:
+
+.. code-block:: bash
+
+    $ sudo brew install redis mongodb
 
 Then you just run ``tox``.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,32 @@ with-coverage = 1
 cover-branches = 1
 cover-inclusive = 1
 cover-tests = 1
+
+[pytest]
+norecursedirs = build docs/_build *.egg .tox *.venv requirements/
+addopts =
+    # Shows a line for every test
+    # You probably want to turn this off if you use pytest-sugar.
+    # Or you can keep it and run `py.test -q`.
+    --verbose
+
+    # Shorter tracebacks are sometimes easier to read
+    # --tb=short
+
+    # Turn on --capture to have brief, less noisy output.
+    # You will only see output if the test fails.
+    # Use --capture no (same as -s) if you want to see it all or have problems
+    # debugging.
+    # --capture=fd
+    # --capture=no
+
+    # Show extra test summary info as specified by chars (f)ailed, (E)error, (s)skipped, (x)failed, (X)passed.
+    -rfEsxX
+
+    # FIXME: This is commented out for now while doing TDD
+    # Measure code coverage
+    --cov=testinstances --cov-report=xml --cov-report=term-missing
+
+    # Previous versions included the following, but it's a bad idea because it
+    # hard-codes the value and makes it hard to change from the command-line
+    # tests/

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+mock

--- a/testinstances/__init__.py
+++ b/testinstances/__init__.py
@@ -16,5 +16,5 @@ limitations under the License.
 
 __version__ = '0.2.0'
 
-from mongo_instance import MongoInstance
-from redis_instance import RedisInstance
+from .mongo_instance import MongoInstance
+from .redis_instance import RedisInstance

--- a/testinstances/compat.py
+++ b/testinstances/compat.py
@@ -1,0 +1,4 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest

--- a/testinstances/managed_instance.py
+++ b/testinstances/managed_instance.py
@@ -54,6 +54,10 @@ class ManagedInstance(object):
         self.name = name
         self.use_gevent = use_gevent
 
+        if self.use_gevent:
+            from gevent import monkey
+            monkey.patch_all()
+
         os.mkdir(self._root_dir)
         try:
             self._start_process()

--- a/testinstances/mongo_instance.py
+++ b/testinstances/mongo_instance.py
@@ -53,18 +53,19 @@ class MongoInstance(ManagedInstance):
             stderr=utils.STDOUT,
             stdout=open(self.logfile, 'w'),
             use_gevent=self.use_gevent,
-            )
+        )
 
         # Connect to the shiny new instance
         self.conn = None
         fails = 0
+
         while self.conn is None:
             try:
-                conn = pymongo.MongoClient(port=self.port,
-                                           use_greenlets=self.use_gevent)
+                conn = pymongo.MongoClient(port=self.port)
                 if conn.alive():
                     self.conn = conn
             except:
+                log.exception('Failed to connect')
                 if fails >= self.timeout:
                     break
                 fails += 1
@@ -77,7 +78,7 @@ class MongoInstance(ManagedInstance):
             except:
                 pass  # file doesn't exist or whatever
             raise ProcessNotStartingError(
-                "Unable to start mongod in {} seconds.".format(self.timeout)
+                "Unable to start mongod in {0} seconds.".format(self.timeout)
             )
 
     def flush(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import logging
+logging.basicConfig()

--- a/tests/testinstances/test_managed_instance.py
+++ b/tests/testinstances/test_managed_instance.py
@@ -1,11 +1,12 @@
 import mock
 import os
 import tempfile
-import unittest
 
+from testinstances.compat import unittest
 from testinstances import managed_instance, MongoInstance, RedisInstance
 from testinstances.exceptions import ProcessRunningError
 from testinstances.managed_instance import ManagedInstance
+
 
 class ManagedInstanceTests(unittest.TestCase):
 

--- a/tests/testinstances/test_redis_instance.py
+++ b/tests/testinstances/test_redis_instance.py
@@ -1,10 +1,18 @@
 import mock
 import os
 import redis
-import unittest
+from testinstances.compat import unittest
+import pytest
 
 from testinstances import managed_instance, RedisInstance
 from testinstances.exceptions import ProcessNotStartingError
+
+try:
+    import gevent
+    HAS_GEVENT = True
+except ImportError:
+    HAS_GEVENT = False
+
 
 class RedisInstanceTests(unittest.TestCase):
 
@@ -29,7 +37,7 @@ class RedisInstanceTests(unittest.TestCase):
         instance = RedisInstance(10101)
 
         instance.conn.set('foo', 'bar')
-        self.assertEqual(instance.conn.get('foo'), 'bar')
+        self.assertEqual(instance.conn.get('foo'), b'bar')
 
         instance.flush()
         self.assertFalse(instance.conn.exists('foo'))
@@ -48,9 +56,10 @@ class RedisInstanceTests(unittest.TestCase):
         here = os.path.split(os.path.abspath(__file__))[0]
         dumpfile = os.path.join(here, './resources/dump.rdb')
         instance = RedisInstance(10101, dumpfile=dumpfile)
-        self.assertEqual(instance.conn.get('foo'), 'bar')
+        self.assertEqual(instance.conn.get('foo'), b'bar')
         instance.terminate()
 
+    @pytest.mark.skipif(not HAS_GEVENT, reason="requires gevent")
     def test_gevent(self):
         """Test starting redis with gevent."""
         instance = RedisInstance(10101, use_gevent=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py26, py27, py34, pypy
+
+[testenv:py26]
+deps = unittest2
+       gevent
+
+[testenv:py27]
+deps = gevent
+
+[testenv]
+commands =
+    pip install -r test-requirements.txt
+    pip install -e .
+    py.test {posargs}


### PR DESCRIPTION
I'm trying to work on `pykafka` to get py34 support but it uses this library for tests.  `pykafka` also supports 26 so I backported this library to work with it.

Other changes I made are that this library isn't compatible with v3 of pymongo so I pinned that to the 2x series.

I switched also switched it to py.test because there were many error failures when I started and it was hard to figure out was wrong with nose, pytest:

1. Is more pythonic, you can use `assert foo == bar` instead of `tools.assert_equal(foo, bar)`
2. py.test is more actively maintained and by an extremely strong maintainer (guy who also created tox and devpi)
3. Better error report, for example look at this:

    ```python
    def test_dict_difference():
        assert {'foo': 'bar'} == {'bar': 'foo'}
    ```

    In nosetests:
    ```
    Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
        self.test(*self.arg)
      File "/home/sontek/venvs/pymemcache/src/test_foo.py", line 2, in test_dict_difference
        assert {'foo': 'bar'} == {'bar': 'foo'}
    AssertionError
    ```

    in pytest:
    ```
        def test_dict_difference():
    >       assert {'foo': 'bar'} == {'bar': 'foo'}
    E       assert {'foo': 'bar'} == {'bar': 'foo'}
    E         Left contains more items:
    E         {'foo': 'bar'}
    E         Right contains more items:
    E         {'bar': 'foo'}
    E         Full diff:
    E         - {'foo': 'bar'}
    E         + {'bar': 'foo'}
    ```
4. For setting up fixtures (dependencies of your tests) you have the ability to use dependency injection to send many different parameters to your test functions (check the integration test file to see this in action)